### PR TITLE
Adjust unit test to handle Windows file paths.

### DIFF
--- a/core/src/test/groovy/nz/govt/natlib/tools/sip/SipFileWrapperFactoryTest.groovy
+++ b/core/src/test/groovy/nz/govt/natlib/tools/sip/SipFileWrapperFactoryTest.groovy
@@ -36,8 +36,11 @@ class SipFileWrapperFactoryTest {
         assertThat("testFileWrapper.mimeType=${testFileWrapper.mimeType}",
                 testFileWrapper.mimeType, is("application/pdf"))
         assertThat("testFileWrapper.file=${testFileWrapper.file}", testFileWrapper.file, is(testFile))
+
+        // Support Windows testing where the file path has backslashes.
+        String adjustedFileOriginalPath = testFileWrapper.fileOriginalPath.replace("\\", "/")
         assertTrue("testFileWrapper.fileOriginalPath=${testFileWrapper.fileOriginalPath}",
-                testFileWrapper.fileOriginalPath.endsWith("nz/govt/natlib/tools/sip"))
+                adjustedFileOriginalPath.endsWith("nz/govt/natlib/tools/sip"))
         assertThat("testFileWrapper.fileOriginalName=${testFileWrapper.fileOriginalName}",
                 testFileWrapper.fileOriginalName, is(SipTestHelper.TEST_PDF_FILE_1_FILENAME))
         assertNull("testFileWrapper.label=${testFileWrapper.label}", testFileWrapper.label)
@@ -88,8 +91,11 @@ class SipFileWrapperFactoryTest {
         assertThat("testFileWrapper.mimeType=${testFileWrapper.mimeType}",
                 testFileWrapper.mimeType, is("application/pdf"))
         assertThat("testFileWrapper.file=${testFileWrapper.file}", testFileWrapper.file, is(testFile))
+
+        // Support Windows testing where the file path has backslashes.
+        String adjustedFileOriginalPath = testFileWrapper.fileOriginalPath.replace("\\", "/")
         assertTrue("testFileWrapper.fileOriginalPath=${testFileWrapper.fileOriginalPath}",
-                testFileWrapper.fileOriginalPath.endsWith("nz/govt/natlib/tools/sip"))
+                adjustedFileOriginalPath.endsWith("nz/govt/natlib/tools/sip"))
         assertThat("testFileWrapper.fileOriginalName=${testFileWrapper.fileOriginalName}",
                 testFileWrapper.fileOriginalName, is(SipTestHelper.TEST_PDF_FILE_1_FILENAME))
         assertNull("testFileWrapper.label=${testFileWrapper.label}", testFileWrapper.label)

--- a/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipJsonGeneratorTest.groovy
+++ b/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipJsonGeneratorTest.groovy
@@ -37,7 +37,11 @@ class SipJsonGeneratorTest {
             if (fileObject != null && (fileObject in JsonPrimitive)) {
                 JsonPrimitive fileStringPrimitive = (JsonPrimitive) fileObject
                 // support testing in Windows. Replace the 'file' object with a path-adjusted file object.
-                fileWrapperObject.addProperty("file", fileStringPrimitive.getAsString().replace("\\", "/"))
+                String fileString =  fileStringPrimitive.getAsString().replace("\\", "/")
+                if (fileString.toLowerCase().startsWith("c:")) {
+                    fileString = fileString.substring(2)
+                }
+                fileWrapperObject.addProperty("file", fileString)
             }
         }
 

--- a/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipJsonGeneratorTest.groovy
+++ b/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipJsonGeneratorTest.groovy
@@ -1,5 +1,8 @@
 package nz.govt.natlib.tools.sip.generation
 
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+
 import static org.hamcrest.core.Is.is
 import static org.junit.Assert.assertThat
 
@@ -29,6 +32,14 @@ class SipJsonGeneratorTest {
         JsonParser jsonParser = new JsonParser()
         JsonElement expectedJson = jsonParser.parse(SipTestHelper.getTextFromResourceOrFile(SipTestHelper.TEST_SIP_JSON_1_FILENAME))
         JsonElement actualJson = jsonParser.parse(jsonString)
+        actualJson.getAsJsonObject().get("fileWrappers").each { JsonObject fileWrapperObject ->
+            JsonElement fileObject = fileWrapperObject.get("file")
+            if (fileObject != null && (fileObject in JsonPrimitive)) {
+                JsonPrimitive fileStringPrimitive = (JsonPrimitive) fileObject
+                // support testing in Windows. Replace the 'file' object with a path-adjusted file object.
+                fileWrapperObject.addProperty("file", fileStringPrimitive.getAsString().replace("\\", "/"))
+            }
+        }
 
         assertThat("Generated JSON matches expected JSON for file=${SipTestHelper.TEST_SIP_JSON_1_FILENAME}",
             expectedJson, is(actualJson))


### PR DESCRIPTION
Adjust unit tests that work with file paths to handle the case where
the file path contains backslashes.