### PR TITLE
Escape characters in file URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
     project.ext {
         vendor = "National Library of New Zealand"
 
-        versionNumber = "1.0.1-SNAPSHOT"
+        versionNumber = "1.0.2-SNAPSHOT"
     }
 
     apply plugin: 'maven'

--- a/core/core.gradle
+++ b/core/core.gradle
@@ -85,6 +85,9 @@ dependencies {
     compile "org.openpreservation.jhove:jhove-core:1.22.1"
     compile "org.openpreservation.jhove:jhove-modules:1.20.1"
 
+    // For URL encoding
+    compile 'com.google.guava:guava:31.1-jre'
+
     // No longer part of the JDK (i.e. not in OpenJDK 11)
     compile "com.sun.activation:javax.activation:1.2.0"
     compile "javax.xml.bind:jaxb-api:2.3.1"

--- a/core/src/main/groovy/nz/govt/natlib/tools/sip/generation/SipXmlGenerator.groovy
+++ b/core/src/main/groovy/nz/govt/natlib/tools/sip/generation/SipXmlGenerator.groovy
@@ -6,6 +6,7 @@ import com.exlibris.digitool.common.dnx.DnxDocument
 import com.exlibris.digitool.common.dnx.DnxDocumentHelper
 import com.exlibris.dps.sdk.deposit.IEParser
 import com.exlibris.dps.sdk.deposit.IEParserFactory
+import com.google.common.net.UrlEscapers
 import gov.loc.mets.FileType
 import gov.loc.mets.MetsType
 import nz.govt.natlib.tools.sip.Sip
@@ -98,7 +99,8 @@ class SipXmlGenerator {
             // Add file and DNX metadata on file
             String mimeType = fileWrapper.getMimeType()
             Path file = fileWrapper.getFile()
-            FileType fileType = ieParser.addNewFile(fileGroup, mimeType, fileWrapper.getFileOriginalName(), "XXX-TO-REPLACE-test file")
+            String encodedLocation = UrlEscapers.urlFragmentEscaper().escape(fileWrapper.fileOriginalName)
+            FileType fileType = ieParser.addNewFile(fileGroup, mimeType, encodedLocation, "XXX-TO-REPLACE-test file")
 
             // File DNX construction
             DnxDocument dnxDocumentFile = ieParser.getFileDnx(fileType.getID())

--- a/core/src/test/groovy/nz/govt/natlib/tools/sip/SipTestHelper.groovy
+++ b/core/src/test/groovy/nz/govt/natlib/tools/sip/SipTestHelper.groovy
@@ -2,6 +2,7 @@ package nz.govt.natlib.tools.sip
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -75,9 +76,9 @@ class SipTestHelper {
         String text
         InputStream inputStream = SipTestHelper.class.getResourceAsStream(filename)
         if (inputStream == null) {
-            Path inputFile = Path.of(localPath)
+            Path inputFile = Paths.get(localPath)
             if (!Files.exists(inputFile)) {
-                inputFile = Path.of("").resolve(localPath)
+                inputFile = Paths.get("").resolve(localPath)
             }
             text = inputFile.text
         } else {
@@ -103,12 +104,12 @@ class SipTestHelper {
         URL resourceURL = SipTestHelper.class.getResource(filename)
         Path resourceFile
         if (resourceURL != null) {
-            resourceFile = Path.of(resourceURL.toURI())
+            resourceFile = Paths.get(resourceURL.toURI())
         }
         if (resourceFile != null && (Files.isRegularFile(resourceFile) || Files.isDirectory(resourceFile))) {
             return resourceFile
         } else {
-            Path returnFile = Path.of(localPath)
+            Path returnFile = Paths.get(localPath)
             return returnFile
         }
     }
@@ -146,7 +147,7 @@ class SipTestHelper {
         while (fileIndex < 4) {
             Sip.FileWrapper fileWrapper = new Sip.FileWrapper()
             fileWrapper.mimeType = SIP_FILE_MIME_TYPE
-            fileWrapper.file = Path.of("${SIP_FILE_BASE}${fileIndex}")
+            fileWrapper.file = Paths.get("${SIP_FILE_BASE}${fileIndex}")
             fileWrapper.fileOriginalPath = "${SIP_FILE_ORIGINAL_PATH_BASE}${fileIndex}"
             fileWrapper.fileOriginalName = "${SIP_FILE_ORIGINAL_NAME_BASE}${fileIndex}"
             fileWrapper.label = "${SIP_FILE_LABEL_BASE}${fileIndex}"

--- a/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipXmlGeneratorTest.groovy
+++ b/core/src/test/groovy/nz/govt/natlib/tools/sip/generation/SipXmlGeneratorTest.groovy
@@ -1,5 +1,7 @@
 package nz.govt.natlib.tools.sip.generation
 
+import org.xmlunit.diff.Difference
+
 import static org.junit.Assert.assertFalse
 
 import nz.govt.natlib.tools.sip.Sip
@@ -52,6 +54,14 @@ class SipXmlGeneratorTest {
                 .ignoreComments()
                 .normalizeWhitespace()
                 .build()
+
+        if (theDiff.hasDifferences()) {
+            StringBuffer buffer = new StringBuffer();
+            for (Difference d: theDiff.getDifferences()) {
+                buffer.append(d.toString());
+            }
+            print(buffer)
+        }
 
         assertFalse("XML for SipTestHelper.sipOne() is the same as generated", theDiff.hasDifferences())
     }


### PR DESCRIPTION
- Adds URL encoding to file URLs to match Rosetta xml validation
- Fixes up syntax that was breaking some tests